### PR TITLE
Fix concurrent request corrupting each other

### DIFF
--- a/nefertari_sqla/signals.py
+++ b/nefertari_sqla/signals.py
@@ -47,7 +47,7 @@ def on_after_update(mapper, connection, target):
     # Reload `target` to get access to processed fields values
     columns = [c.name for c in class_mapper(target.__class__).columns]
     object_session(target).expire(target, attribute_names=columns)
-    index_object(target, request=request, nested_only=True)
+    index_object(target, request=request, nested_only=True, with_refs=False)
 
 
 def on_after_delete(mapper, connection, target):


### PR DESCRIPTION
It seems like update requests signals don't require relations reindexing.
